### PR TITLE
Coralnet support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Use hosted
 
 The explorer is deployed at https://cosmwasm.github.io/code-explorer and is configured
-for Demonet.
+for Coralnet.
 
 ## Run locally
 

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
     ]
   },
   "dependencies": {
-    "@cosmjs/cosmwasm": "^0.22.1",
-    "@cosmjs/encoding": "^0.22.1",
-    "@cosmjs/launchpad": "^0.22.1",
-    "@cosmjs/math": "^0.22.1",
-    "@cosmjs/utils": "^0.22.1",
+    "@cosmjs/cosmwasm": "^0.23.0-alpha.0",
+    "@cosmjs/encoding": "^0.23.0-alpha.0",
+    "@cosmjs/launchpad": "^0.23.0-alpha.0",
+    "@cosmjs/math": "^0.23.0-alpha.0",
+    "@cosmjs/utils": "^0.23.0-alpha.0",
     "@types/jest": "^24.0.0",
     "@types/jquery": "^3.3.33",
     "@types/node": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
   "license": "Apache-2.0",
   "scripts": {
     "start": "react-scripts start",
-    "start-demonet": "REACT_APP_BACKEND=demonet yarn start",
+    "start-coralnet": "REACT_APP_BACKEND=coralnet yarn start",
     "start-regen": "REACT_APP_BACKEND=regen yarn start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "lint": "eslint -c .eslintrc.js --max-warnings 0 'src/**/*.ts{,x}'",
     "lint-fix": "eslint -c .eslintrc.js 'src/**/*.ts{,x}' --fix",
-    "deploy": "PUBLIC_URL=https://cosmwasm.github.io/code-explorer/ REACT_APP_BACKEND=demonet yarn build && gh-pages -d build"
+    "deploy": "PUBLIC_URL=https://cosmwasm.github.io/code-explorer/ REACT_APP_BACKEND=coralnet yarn build && gh-pages -d build"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/src/settings/backend.ts
+++ b/src/settings/backend.ts
@@ -4,8 +4,8 @@ export interface BackendSettings {
   readonly nodeUrls: NonEmptyArray<string>;
 }
 
-const demonetSettings: BackendSettings = {
-  nodeUrls: ["https://lcd.demo-10.cosmwasm.com"],
+const coralnetSettings: BackendSettings = {
+  nodeUrls: ["https://lcd.coralnet.cosmwasm.com"],
 };
 
 const devnetSettings: BackendSettings = {
@@ -18,7 +18,7 @@ const regenSettings: BackendSettings = {
 
 const knownBackends: { [index: string]: BackendSettings } = {
   devnet: devnetSettings,
-  demonet: demonetSettings,
+  coralnet: coralnetSettings,
   regen: regenSettings,
 };
 

--- a/src/settings/backend.ts
+++ b/src/settings/backend.ts
@@ -17,8 +17,8 @@ const regenSettings: BackendSettings = {
 };
 
 const knownBackends: { [index: string]: BackendSettings } = {
-  devnet: devnetSettings,
   coralnet: coralnetSettings,
+  devnet: devnetSettings,
   regen: regenSettings,
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1067,27 +1067,27 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@cosmjs/cosmwasm@^0.22.1":
-  version "0.22.1"
-  resolved "https://registry.yarnpkg.com/@cosmjs/cosmwasm/-/cosmwasm-0.22.1.tgz#38fcf73e5626844dd806eb9805b34a695b659d04"
-  integrity sha512-zYcojduoJA2Dclo9uBaf3Oh/O916GCXHGdB/y+u6aECazDpXm9GfeD/J8aIhQDcOokcW8sDmmdYKsSS3g//RCg==
+"@cosmjs/cosmwasm@^0.23.0-alpha.0":
+  version "0.23.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@cosmjs/cosmwasm/-/cosmwasm-0.23.0-alpha.0.tgz#9a9408cd1b4f7912694dfdfd23630be3fbb6cd38"
+  integrity sha512-BI4qEnFw2nDRUiR2egSmnsajkzlhCyhPKb+kdlqBrIyRmFucHx5cOadZBq4+X/zSciOtWlS3fpaurwhEnZBk4A==
   dependencies:
-    "@cosmjs/crypto" "^0.22.1"
-    "@cosmjs/encoding" "^0.22.1"
-    "@cosmjs/launchpad" "^0.22.1"
-    "@cosmjs/math" "^0.22.1"
-    "@cosmjs/utils" "^0.22.1"
+    "@cosmjs/crypto" "^0.23.0-alpha.0"
+    "@cosmjs/encoding" "^0.23.0-alpha.0"
+    "@cosmjs/launchpad" "^0.23.0-alpha.0"
+    "@cosmjs/math" "^0.23.0-alpha.0"
+    "@cosmjs/utils" "^0.23.0-alpha.0"
     axios "^0.19.0"
     pako "^1.0.11"
 
-"@cosmjs/crypto@^0.22.1":
-  version "0.22.1"
-  resolved "https://registry.yarnpkg.com/@cosmjs/crypto/-/crypto-0.22.1.tgz#b5f2c43473a89ccb0aabd9aa76f3992db68a5907"
-  integrity sha512-ZWjrVNRpbmB15BCv4c+KeWHYq6sOyTW6FT9Nh3JShNufwrMo1EbqdjqQcI5EH/EcooyehiwqvCB9rJesZTsFpQ==
+"@cosmjs/crypto@^0.23.0-alpha.0":
+  version "0.23.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@cosmjs/crypto/-/crypto-0.23.0-alpha.0.tgz#610bd533ec49ec0a7bce9dd7a0a4414b2fafea87"
+  integrity sha512-lLYVBHwJc49VQy55Zo5qsKozhkSwYHI8+e19ApRouK6SV/lbQXPTWTHY/K0duavH9uUesbHhqYc/ZpT8cTXzcw==
   dependencies:
-    "@cosmjs/encoding" "^0.22.1"
-    "@cosmjs/math" "^0.22.1"
-    "@cosmjs/utils" "^0.22.1"
+    "@cosmjs/encoding" "^0.23.0-alpha.0"
+    "@cosmjs/math" "^0.23.0-alpha.0"
+    "@cosmjs/utils" "^0.23.0-alpha.0"
     bip39 "^3.0.2"
     bn.js "^4.11.8"
     elliptic "^6.5.3"
@@ -1099,37 +1099,37 @@
     type-tagger "^1.0.0"
     unorm "^1.5.0"
 
-"@cosmjs/encoding@^0.22.1":
-  version "0.22.1"
-  resolved "https://registry.yarnpkg.com/@cosmjs/encoding/-/encoding-0.22.1.tgz#0edd4fa9046c5033a8ef5fe37b9ec5029e164413"
-  integrity sha512-iIGqtkbLFjjBj+UDyskrrSGXzAa2KK6Zc/6Pujl2Bt5gNPF+ljTBlQr1jkem15LPMxycDXGSgAt6JEUlF7X/BA==
+"@cosmjs/encoding@^0.23.0-alpha.0":
+  version "0.23.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@cosmjs/encoding/-/encoding-0.23.0-alpha.0.tgz#450b200ef94d98a13e23bab12073796d0df5c98a"
+  integrity sha512-oug83s6PuqhAAg5wPtlVKdiDkLYKauDzcJ513K427K/uHdrAzLujE0Wk33EnKUtdMoUZRUa0LN6gxi6V15lvpg==
   dependencies:
     base64-js "^1.3.0"
     bech32 "^1.1.4"
     readonly-date "^1.0.0"
 
-"@cosmjs/launchpad@^0.22.1":
-  version "0.22.1"
-  resolved "https://registry.yarnpkg.com/@cosmjs/launchpad/-/launchpad-0.22.1.tgz#c3ab68c8146add81635f1bc66e07d894278505fd"
-  integrity sha512-ZWpygxR+/50GO98MU/nt07K2xl/gXv9AbeESMXEAS2MoUqjvP0bHvzCtHJEhHQG1mKQAI2YYIc9uWir47fyaew==
+"@cosmjs/launchpad@^0.23.0-alpha.0":
+  version "0.23.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@cosmjs/launchpad/-/launchpad-0.23.0-alpha.0.tgz#b6d070958dfff5c3232dba180289ed8074e11adc"
+  integrity sha512-Aznet2bqX6j2f/ONHg0s2N6XgNmPW6TozMwwvrEUdMSaODcXo7+H2iOc8i80fCgQDj3I5WcObfMSAigPyv0r7A==
   dependencies:
-    "@cosmjs/crypto" "^0.22.1"
-    "@cosmjs/encoding" "^0.22.1"
-    "@cosmjs/math" "^0.22.1"
-    "@cosmjs/utils" "^0.22.1"
+    "@cosmjs/crypto" "^0.23.0-alpha.0"
+    "@cosmjs/encoding" "^0.23.0-alpha.0"
+    "@cosmjs/math" "^0.23.0-alpha.0"
+    "@cosmjs/utils" "^0.23.0-alpha.0"
     axios "^0.19.0"
 
-"@cosmjs/math@^0.22.1":
-  version "0.22.1"
-  resolved "https://registry.yarnpkg.com/@cosmjs/math/-/math-0.22.1.tgz#1bb12a6692715aec04d4fc48e83d69a128ead062"
-  integrity sha512-oHBP5nG1vzo+wfF/1C4TT1lJ+oV+0zh4OdtNxKvMTqKinceb4e1mJjvwnQ61bGlK2j646XrP1ROVmCudLo2iEA==
+"@cosmjs/math@^0.23.0-alpha.0":
+  version "0.23.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@cosmjs/math/-/math-0.23.0-alpha.0.tgz#1a470f6c879b47f2b25565233f2078bf006d89ab"
+  integrity sha512-Dfj0WuEJvE2RdKtkWGWgPOSyRS1zsYf1MyLjwhQAphPTxC+6ERIOcpT+BnxJrzLxmLlKWPZ0WWBptLXrK+um6w==
   dependencies:
     bn.js "^4.11.8"
 
-"@cosmjs/utils@^0.22.1":
-  version "0.22.1"
-  resolved "https://registry.yarnpkg.com/@cosmjs/utils/-/utils-0.22.1.tgz#8d4d5afd9829543b712269ddf0ae15996e348a4e"
-  integrity sha512-9HovPmAa7bI4g/X+IPPLJe5AuG6Dko5bncnLvatKIDsiw3zZmC29VtTcnb8EApNXpwygQUS5qAhwUSGdstqPaQ==
+"@cosmjs/utils@^0.23.0-alpha.0":
+  version "0.23.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@cosmjs/utils/-/utils-0.23.0-alpha.0.tgz#de98caa9ed5e25e53415a24dfc7397c4e2dcd8ba"
+  integrity sha512-vQeU5POPTojm/QzmL+Guk+llCH5+tXdPVHyiGtfwuX8sVF29rKk6EwrCK7ix/fYv5Jen193ijYNjK7HplVWANg==
 
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"


### PR DESCRIPTION
Closes #21.

- Updates CosmJS to v0.23.0-alpha.0
- Adds support for Coralnet (and removes Demonet)