### PR TITLE
Fix backend settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "start": "react-scripts start",
-    "start-stargate": "REACT_APP_STARGATE=1 yarn start",
+    "start-stargate": "REACT_APP_BACKEND=devnetStargate yarn start",
     "start-coralnet": "REACT_APP_BACKEND=coralnet yarn start",
     "start-heldernet": "REACT_APP_BACKEND=heldernet yarn start",
     "start-regen": "REACT_APP_BACKEND=regen yarn start",

--- a/src/settings/backend.ts
+++ b/src/settings/backend.ts
@@ -7,13 +7,13 @@ export interface BackendSettings {
 }
 
 const devnetStargateSettings: BackendSettings = {
-  nodeUrls: [`http://localhost:26659`],
+  nodeUrls: ["http://localhost:26659"],
   stargateEnabled: true,
   denominations: ["ucosm", "ustake"],
 };
 
 const devnetLaunchpadSettings: BackendSettings = {
-  nodeUrls: [`http://localhost:1317`],
+  nodeUrls: ["http://localhost:1317"],
   stargateEnabled: false,
   denominations: ["ucosm", "ustake"],
 };
@@ -45,7 +45,6 @@ const knownBackends: { [index: string]: BackendSettings } = {
 };
 
 export function getCurrentBackend(): BackendSettings {
-  return knownBackends[
-    process.env.REACT_APP_BACKEND || process.env.REACT_APP_STARGATE ? "devnetStargate" : "devnetLaunchpad"
-  ];
+  const id = process.env.REACT_APP_BACKEND || "devnetLaunchpad";
+  return knownBackends[id];
 }


### PR DESCRIPTION
`||` seems to bind stronger than the `?`/`:` expression, making the backend always one of `"devnetStargate" : "devnetLaunchpad"`