### PR TITLE
Use @cosmjs/cosmwasm-launchpad directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     ]
   },
   "dependencies": {
-    "@cosmjs/cosmwasm": "^0.24.0-alpha.11",
+    "@cosmjs/cosmwasm-launchpad": "^0.24.0-alpha.11",
     "@cosmjs/cosmwasm-stargate": "^0.24.0-alpha.11",
     "@cosmjs/encoding": "^0.24.0-alpha.11",
     "@cosmjs/launchpad": "^0.24.0-alpha.11",

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,4 +1,4 @@
-import { SigningCosmWasmClient } from "@cosmjs/cosmwasm";
+import { SigningCosmWasmClient } from "@cosmjs/cosmwasm-launchpad";
 import { codec } from "@cosmjs/cosmwasm-stargate";
 import { Registry } from "@cosmjs/proto-signing";
 import React from "react";

--- a/src/contexts/ClientContext.tsx
+++ b/src/contexts/ClientContext.tsx
@@ -1,4 +1,4 @@
-import { SigningCosmWasmClient } from "@cosmjs/cosmwasm";
+import { SigningCosmWasmClient } from "@cosmjs/cosmwasm-launchpad";
 import { Registry } from "@cosmjs/proto-signing";
 import React from "react";
 

--- a/src/pages/code/CodeInfo.tsx
+++ b/src/pages/code/CodeInfo.tsx
@@ -1,4 +1,4 @@
-import { CodeDetails } from "@cosmjs/cosmwasm";
+import { CodeDetails } from "@cosmjs/cosmwasm-launchpad";
 import React from "react";
 
 import { AccountLink } from "../../components/AccountLink";

--- a/src/pages/code/CodePage.tsx
+++ b/src/pages/code/CodePage.tsx
@@ -1,6 +1,6 @@
 import "./CodePage.css";
 
-import { CodeDetails, Contract } from "@cosmjs/cosmwasm";
+import { CodeDetails, Contract } from "@cosmjs/cosmwasm-launchpad";
 import React from "react";
 import { Link, useParams } from "react-router-dom";
 

--- a/src/pages/code/InstanceRow.tsx
+++ b/src/pages/code/InstanceRow.tsx
@@ -1,4 +1,4 @@
-import { Contract } from "@cosmjs/cosmwasm";
+import { Contract } from "@cosmjs/cosmwasm-launchpad";
 import React from "react";
 
 import { AccountLink } from "../../components/AccountLink";

--- a/src/pages/contract/ContractPage.tsx
+++ b/src/pages/contract/ContractPage.tsx
@@ -5,7 +5,7 @@ import {
   ContractCodeHistoryEntry,
   isMsgExecuteContract,
   MsgExecuteContract,
-} from "@cosmjs/cosmwasm";
+} from "@cosmjs/cosmwasm-launchpad";
 import { Coin, IndexedTx as LaunchpadIndexedTx } from "@cosmjs/launchpad";
 import { Registry } from "@cosmjs/proto-signing";
 import { codec, IndexedTx } from "@cosmjs/stargate";

--- a/src/pages/contract/ExecuteContract.tsx
+++ b/src/pages/contract/ExecuteContract.tsx
@@ -1,4 +1,4 @@
-import { ExecuteResult } from "@cosmjs/cosmwasm";
+import { ExecuteResult } from "@cosmjs/cosmwasm-launchpad";
 import { Coin } from "@cosmjs/launchpad";
 import React from "react";
 import JSONInput from "react-json-editor-ajrm";

--- a/src/pages/contract/HistoryInfo.tsx
+++ b/src/pages/contract/HistoryInfo.tsx
@@ -1,4 +1,4 @@
-import { ContractCodeHistoryEntry } from "@cosmjs/cosmwasm";
+import { ContractCodeHistoryEntry } from "@cosmjs/cosmwasm-launchpad";
 import React from "react";
 
 import { CodeLink } from "../../components/CodeLink";

--- a/src/pages/contract/InitializationInfo.tsx
+++ b/src/pages/contract/InitializationInfo.tsx
@@ -1,4 +1,4 @@
-import { Contract } from "@cosmjs/cosmwasm";
+import { Contract } from "@cosmjs/cosmwasm-launchpad";
 import React from "react";
 
 import { AccountLink } from "../../components/AccountLink";

--- a/src/ui-utils/clients.ts
+++ b/src/ui-utils/clients.ts
@@ -1,4 +1,8 @@
-import { CosmWasmClient as LaunchpadClient, CosmWasmFeeTable, SigningCosmWasmClient } from "@cosmjs/cosmwasm";
+import {
+  CosmWasmClient as LaunchpadClient,
+  CosmWasmFeeTable,
+  SigningCosmWasmClient,
+} from "@cosmjs/cosmwasm-launchpad";
 import { CosmWasmClient as StargateClient } from "@cosmjs/cosmwasm-stargate";
 import { Bip39, Random } from "@cosmjs/crypto";
 import { GasLimits, GasPrice, makeCosmoshubPath, OfflineSigner, Secp256k1HdWallet } from "@cosmjs/launchpad";

--- a/src/ui-utils/txs.ts
+++ b/src/ui-utils/txs.ts
@@ -2,7 +2,7 @@ import {
   isMsgExecuteContract as isLaunchpadMsgExecuteContract,
   isMsgInstantiateContract as isLaunchpadMsgInstantiateContract,
   isMsgStoreCode as isLaunchpadMsgStoreCode,
-} from "@cosmjs/cosmwasm";
+} from "@cosmjs/cosmwasm-launchpad";
 import { fromBase64 } from "@cosmjs/encoding";
 import { isMsgSend as isLaunchpadMsgSend, Msg, pubkeyType, WrappedStdTx } from "@cosmjs/launchpad";
 import { Registry } from "@cosmjs/proto-signing";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1113,13 +1113,6 @@
     pako "^2.0.2"
     protobufjs "~6.10.2"
 
-"@cosmjs/cosmwasm@^0.24.0-alpha.11":
-  version "0.24.0-alpha.11"
-  resolved "https://registry.yarnpkg.com/@cosmjs/cosmwasm/-/cosmwasm-0.24.0-alpha.11.tgz#eb46091ba6f2692ac302492adea1ead0ae5c9ca8"
-  integrity sha512-nCjuK6dfp0fr35o5SpmBMgKyzpqfPywpCOQvalaCXmuw9Z7bkBzJ5cYOt+isZW6DrAarF1MBG2d1tgYQX7+S9Q==
-  dependencies:
-    "@cosmjs/cosmwasm-launchpad" "^0.24.0-alpha.11"
-
 "@cosmjs/crypto@^0.24.0-alpha.11":
   version "0.24.0-alpha.11"
   resolved "https://registry.yarnpkg.com/@cosmjs/crypto/-/crypto-0.24.0-alpha.11.tgz#e8a9bdf6b6fd73cb7afd31340f25fa321a723ee8"


### PR DESCRIPTION
Starting with CosmJS 0.24, `@cosmjs/cosmwasm` is an alias to the new explicit `@cosmjs/cosmwasm-launchpad` package. Let's use the real package directly.